### PR TITLE
Fix SASS for latest notification structure

### DIFF
--- a/src/gtk-3.0/sass/apps/_budgie.scss
+++ b/src/gtk-3.0/sass/apps/_budgie.scss
@@ -657,16 +657,16 @@ calendar.raven-calendar {
 
 // Notifications
 .budgie-notification-window {
-  background-color: theme-color.$inverse-surface-z1;
-  color: theme-color.$inverse-surface-z8;
+  background-color: transparent;
 
-  border-radius: theme.$corner-radius;
-
-  box, stack {
-    background-color: transparent;
-    border: none;
-    box-shadow: none;
+  .drop-shadow {
+    background-color: theme-color.$inverse-surface-z1;
+    color: theme-color.$inverse-surface-z8;
+    border-radius: theme.$corner-radius;
+    padding: theme.$container-padding;
+    margin: 0;
   }
+
   button {
     color: theme-color.$inverse-surface-z8;
   }
@@ -675,11 +675,6 @@ calendar.raven-calendar {
 .budgie-notification {
   .notification-title {
     font-size: 120%;
-  }
-
-  .notification-body {
-    //color: theme-color.hint(theme-color.$on-surface);
-    color: theme-color.$inverse-surface-z8;
   }
 }
 


### PR DESCRIPTION
The current theme looks a little off with the current (10.8) notification structure. The box shadow is solid but a slightly different color, and the padding doesn't quite seem right. This fixes all of that.

Pictures are worth thousands of words, so I'll let them do the talking.

Before:
![image](https://github.com/UbuntuBudgie/pocillo-gtk-theme/assets/5157277/2bdc9679-56fa-4da9-aa92-b988af861b1f)

After:
![image](https://github.com/UbuntuBudgie/pocillo-gtk-theme/assets/5157277/01c9b5c4-e21c-49ca-9634-e7ce070375f4)
