### PR TITLE
Fix bug preventing compilation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,8 +21,7 @@ sass = find_program('sass', required: false)
 sass_opts = ['--no-source-map']
 
 if sass.found()
-  sass_full_version = run_command(sass, '--version',
-                                  version:'>= 1.23.0').stdout()
+  sass_full_version = run_command(sass, '--version').stdout()
   sass_is_ruby_sass = sass_full_version.contains('Ruby Sass')
   sass_has_module_system = sass_full_version.version_compare('>= 1.23.0')
 endif


### PR DESCRIPTION
This line causes Meson to throw an error as it doesn't expect version as an argument.
`meson.build:24:22: ERROR: run_command got unknown keyword arguments "version"`